### PR TITLE
test: エッジケース・エラーケースのテストを追加

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -164,3 +164,161 @@ func TestCreateListEmptyTitle(t *testing.T) {
 		t.Fatalf("expected 400, got %d", w.Code)
 	}
 }
+
+func TestCreateListWhitespaceTitle(t *testing.T) {
+	mux, _ := setupTestServer()
+	form := url.Values{"title": {"   "}}
+	req := httptest.NewRequest("POST", "/lists", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for whitespace-only title, got %d", w.Code)
+	}
+}
+
+func TestDeleteList(t *testing.T) {
+	mux, store := setupTestServer()
+	l := store.CreateList("削除テスト", "")
+	token := l.ShareToken
+
+	req := httptest.NewRequest("POST", "/lists/"+token+"/delete", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", w.Code)
+	}
+	if loc := w.Header().Get("Location"); loc != "/" {
+		t.Fatalf("expected redirect to /, got %s", loc)
+	}
+	if store.GetList(token) != nil {
+		t.Fatal("expected list to be deleted from store")
+	}
+}
+
+func TestDeleteListNotFound(t *testing.T) {
+	mux, _ := setupTestServer()
+	req := httptest.NewRequest("POST", "/lists/nonexistent-token/delete", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestAddItemEmptyName(t *testing.T) {
+	mux, store := setupTestServer()
+	l := store.CreateList("テスト", "")
+	token := l.ShareToken
+
+	form := url.Values{"name": {""}, "assignee": {"太郎"}}
+	req := httptest.NewRequest("POST", "/lists/"+token+"/items", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	// Should redirect without adding item
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", w.Code)
+	}
+	if len(store.GetList(token).Items) != 0 {
+		t.Fatal("expected no items to be added for empty name")
+	}
+}
+
+func TestAddItemWhitespaceName(t *testing.T) {
+	mux, store := setupTestServer()
+	l := store.CreateList("テスト", "")
+	token := l.ShareToken
+
+	form := url.Values{"name": {"   "}}
+	req := httptest.NewRequest("POST", "/lists/"+token+"/items", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", w.Code)
+	}
+	if len(store.GetList(token).Items) != 0 {
+		t.Fatal("expected no items to be added for whitespace-only name")
+	}
+}
+
+func TestTogglePreparedInvalidItem(t *testing.T) {
+	mux, store := setupTestServer()
+	l := store.CreateList("テスト", "")
+	token := l.ShareToken
+
+	req := httptest.NewRequest("POST", "/lists/"+token+"/items/nonexistent-id/toggle-prepared", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	// Handler should redirect gracefully even for invalid item ID
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 redirect for invalid item ID, got %d", w.Code)
+	}
+}
+
+func TestToggleRequiredInvalidItem(t *testing.T) {
+	mux, store := setupTestServer()
+	l := store.CreateList("テスト", "")
+	token := l.ShareToken
+
+	req := httptest.NewRequest("POST", "/lists/"+token+"/items/nonexistent-id/toggle-required", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 redirect for invalid item ID, got %d", w.Code)
+	}
+}
+
+func TestUpdateAssigneeInvalidItem(t *testing.T) {
+	mux, store := setupTestServer()
+	l := store.CreateList("テスト", "")
+	token := l.ShareToken
+
+	form := url.Values{"assignee": {"花子"}}
+	req := httptest.NewRequest("POST", "/lists/"+token+"/items/nonexistent-id/assignee", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 redirect for invalid item ID, got %d", w.Code)
+	}
+}
+
+func TestDeleteItemInvalidItem(t *testing.T) {
+	mux, store := setupTestServer()
+	l := store.CreateList("テスト", "")
+	store.AddItem(l.ShareToken, "アイテム", "", true)
+	token := l.ShareToken
+
+	req := httptest.NewRequest("POST", "/lists/"+token+"/items/nonexistent-id/delete", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303 redirect for invalid item ID, got %d", w.Code)
+	}
+	// Existing item should still be there
+	if len(store.GetList(token).Items) != 1 {
+		t.Fatal("expected existing item to remain after deleting nonexistent ID")
+	}
+}
+
+func TestIndexPageNotFound(t *testing.T) {
+	mux, _ := setupTestServer()
+	req := httptest.NewRequest("GET", "/nonexistent-path", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown path, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## 概要

Issue #7 対応。正常系のみカバーしていたテストに、エラーケースと境界値テストを追加した。

## 追加したテストケース

- **TestCreateListWhitespaceTitle** - 空白のみのタイトルで400を返すことを確認
- **TestDeleteList** - リスト削除の正常系（削除後に `/` へリダイレクト、ストアからも削除される）
- **TestDeleteListNotFound** - 存在しないトークンのリスト削除で404を返すことを確認
- **TestAddItemEmptyName** - アイテム名が空の場合はアイテムを追加せずリダイレクト
- **TestAddItemWhitespaceName** - アイテム名が空白のみの場合もアイテムを追加しない
- **TestTogglePreparedInvalidItem** - 存在しないアイテムIDでもリダイレクトで正常応答
- **TestToggleRequiredInvalidItem** - 存在しないアイテムIDでもリダイレクトで正常応答
- **TestUpdateAssigneeInvalidItem** - 存在しないアイテムIDでもリダイレクトで正常応答
- **TestDeleteItemInvalidItem** - 存在しないアイテムIDの削除では既存アイテムに影響なし
- **TestIndexPageNotFound** - ルート以外のパスで404を返すことを確認

## テスト確認

```
ok  github.com/mohadayo/bringit  0.010s
```

https://claude.ai/code/session_01Q5pVDrbT49Ta9PuDJeB6G2