### PR TITLE
fix: 存在しないリストに対するアイテム操作で404を返すように修正

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -142,6 +142,10 @@ func handleShowList(store *Store) http.HandlerFunc {
 func handleAddItem(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if store.GetList(token) == nil {
+			http.NotFound(w, r)
+			return
+		}
 		name := strings.TrimSpace(r.FormValue("name"))
 		if name == "" {
 			http.Redirect(w, r, "/lists/"+token, http.StatusSeeOther)
@@ -158,6 +162,10 @@ func handleAddItem(store *Store) http.HandlerFunc {
 func handleTogglePrepared(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if store.GetList(token) == nil {
+			http.NotFound(w, r)
+			return
+		}
 		id := r.PathValue("id")
 		store.TogglePrepared(token, id)
 		http.Redirect(w, r, "/lists/"+token, http.StatusSeeOther)
@@ -167,6 +175,10 @@ func handleTogglePrepared(store *Store) http.HandlerFunc {
 func handleToggleRequired(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if store.GetList(token) == nil {
+			http.NotFound(w, r)
+			return
+		}
 		id := r.PathValue("id")
 		store.ToggleRequired(token, id)
 		http.Redirect(w, r, "/lists/"+token, http.StatusSeeOther)
@@ -176,6 +188,10 @@ func handleToggleRequired(store *Store) http.HandlerFunc {
 func handleUpdateAssignee(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if store.GetList(token) == nil {
+			http.NotFound(w, r)
+			return
+		}
 		id := r.PathValue("id")
 		assignee := truncateRunes(strings.TrimSpace(r.FormValue("assignee")), maxAssigneeLen)
 		store.UpdateAssignee(token, id, assignee)
@@ -186,6 +202,10 @@ func handleUpdateAssignee(store *Store) http.HandlerFunc {
 func handleDeleteItem(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if store.GetList(token) == nil {
+			http.NotFound(w, r)
+			return
+		}
 		id := r.PathValue("id")
 		store.DeleteItem(token, id)
 		http.Redirect(w, r, "/lists/"+token, http.StatusSeeOther)

--- a/handler_test.go
+++ b/handler_test.go
@@ -503,6 +503,65 @@ func TestUpdateAssigneeTruncation(t *testing.T) {
 	}
 }
 
+func TestHandlerAddItemToNonExistentList(t *testing.T) {
+	mux, _ := setupTestServer()
+	form := url.Values{"name": {"テント"}, "assignee": {"太郎"}}
+	req := httptest.NewRequest("POST", "/lists/nonexistent-token/items", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for adding item to non-existent list, got %d", w.Code)
+	}
+}
+
+func TestTogglePreparedOnNonExistentList(t *testing.T) {
+	mux, _ := setupTestServer()
+	req := httptest.NewRequest("POST", "/lists/nonexistent-token/items/1/toggle-prepared", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for toggle-prepared on non-existent list, got %d", w.Code)
+	}
+}
+
+func TestToggleRequiredOnNonExistentList(t *testing.T) {
+	mux, _ := setupTestServer()
+	req := httptest.NewRequest("POST", "/lists/nonexistent-token/items/1/toggle-required", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for toggle-required on non-existent list, got %d", w.Code)
+	}
+}
+
+func TestUpdateAssigneeOnNonExistentList(t *testing.T) {
+	mux, _ := setupTestServer()
+	form := url.Values{"assignee": {"花子"}}
+	req := httptest.NewRequest("POST", "/lists/nonexistent-token/items/1/assignee", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for update assignee on non-existent list, got %d", w.Code)
+	}
+}
+
+func TestDeleteItemOnNonExistentList(t *testing.T) {
+	mux, _ := setupTestServer()
+	req := httptest.NewRequest("POST", "/lists/nonexistent-token/items/1/delete", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for delete item on non-existent list, got %d", w.Code)
+	}
+}
+
 func TestSecurityHeaders(t *testing.T) {
 	mux, _ := setupTestServer()
 	handler := securityHeaders(mux)


### PR DESCRIPTION
## 変更概要

- `handleAddItem`, `handleTogglePrepared`, `handleToggleRequired`, `handleUpdateAssignee`, `handleDeleteItem` に `store.GetList(token)` による存在チェックを追加
- 存在しないリストトークンに対する操作で、サイレントリダイレクトではなく404を返すように修正
- 存在しないリストに対する操作テスト5件を追加

Closes #23

## 動作確認手順
1. `go test -v -race ./...` で全テスト通過を確認
2. `go vet ./...` でコード品質チェック通過を確認
3. 存在しないリストトークンでアイテム追加 → 404レスポンスを確認