### PR TITLE
セキュリティ強化: CSPヘッダ追加・トークンバリデーション・トークンサイズ拡大

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -53,6 +54,8 @@ var tmpl = template.Must(template.New("").Funcs(template.FuncMap{
 		return done * 100 / len(items)
 	},
 }).ParseGlob("templates/*.html"))
+
+var validToken = regexp.MustCompile(`^[a-f0-9]{32}$`)
 
 func registerRoutes(mux *http.ServeMux, store *Store) {
 	mux.HandleFunc("GET /health", handleHealth)
@@ -123,6 +126,10 @@ func handleCreateList(store *Store) http.HandlerFunc {
 func handleShowList(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if !validToken.MatchString(token) {
+			http.Error(w, "無効なトークン形式です", http.StatusBadRequest)
+			return
+		}
 		l := store.GetList(token)
 		if l == nil {
 			http.NotFound(w, r)
@@ -142,6 +149,10 @@ func handleShowList(store *Store) http.HandlerFunc {
 func handleAddItem(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if !validToken.MatchString(token) {
+			http.Error(w, "無効なトークン形式です", http.StatusBadRequest)
+			return
+		}
 		name := strings.TrimSpace(r.FormValue("name"))
 		if name == "" {
 			http.Redirect(w, r, "/lists/"+token, http.StatusSeeOther)
@@ -158,6 +169,10 @@ func handleAddItem(store *Store) http.HandlerFunc {
 func handleTogglePrepared(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if !validToken.MatchString(token) {
+			http.Error(w, "無効なトークン形式です", http.StatusBadRequest)
+			return
+		}
 		id := r.PathValue("id")
 		store.TogglePrepared(token, id)
 		http.Redirect(w, r, "/lists/"+token, http.StatusSeeOther)
@@ -167,6 +182,10 @@ func handleTogglePrepared(store *Store) http.HandlerFunc {
 func handleToggleRequired(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if !validToken.MatchString(token) {
+			http.Error(w, "無効なトークン形式です", http.StatusBadRequest)
+			return
+		}
 		id := r.PathValue("id")
 		store.ToggleRequired(token, id)
 		http.Redirect(w, r, "/lists/"+token, http.StatusSeeOther)
@@ -176,6 +195,10 @@ func handleToggleRequired(store *Store) http.HandlerFunc {
 func handleUpdateAssignee(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if !validToken.MatchString(token) {
+			http.Error(w, "無効なトークン形式です", http.StatusBadRequest)
+			return
+		}
 		id := r.PathValue("id")
 		assignee := truncateRunes(strings.TrimSpace(r.FormValue("assignee")), maxAssigneeLen)
 		store.UpdateAssignee(token, id, assignee)
@@ -186,6 +209,10 @@ func handleUpdateAssignee(store *Store) http.HandlerFunc {
 func handleDeleteItem(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if !validToken.MatchString(token) {
+			http.Error(w, "無効なトークン形式です", http.StatusBadRequest)
+			return
+		}
 		id := r.PathValue("id")
 		store.DeleteItem(token, id)
 		http.Redirect(w, r, "/lists/"+token, http.StatusSeeOther)
@@ -195,6 +222,10 @@ func handleDeleteItem(store *Store) http.HandlerFunc {
 func handleDeleteList(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if !validToken.MatchString(token) {
+			http.Error(w, "無効なトークン形式です", http.StatusBadRequest)
+			return
+		}
 		if !store.DeleteList(token) {
 			http.NotFound(w, r)
 			return

--- a/handler_test.go
+++ b/handler_test.go
@@ -172,7 +172,7 @@ func TestUpdateAssignee(t *testing.T) {
 
 func TestNotFoundList(t *testing.T) {
 	mux, _ := setupTestServer()
-	req := httptest.NewRequest("GET", "/lists/nonexistent", nil)
+	req := httptest.NewRequest("GET", "/lists/00112233445566778899aabbccddeeff", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -229,7 +229,7 @@ func TestDeleteList(t *testing.T) {
 
 func TestDeleteListNotFound(t *testing.T) {
 	mux, _ := setupTestServer()
-	req := httptest.NewRequest("POST", "/lists/nonexistent-token/delete", nil)
+	req := httptest.NewRequest("POST", "/lists/00112233445566778899aabbccddeeff/delete", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -243,7 +243,7 @@ func TestAddItemEmptyName(t *testing.T) {
 	l := store.CreateList("テスト", "")
 	token := l.ShareToken
 
-	form := url.Values{"name": {""}, "assignee": {"太郎"}}
+	form := url.Values{"name": {""},  "assignee": {"太郎"}}
 	req := httptest.NewRequest("POST", "/lists/"+token+"/items", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
@@ -400,7 +400,6 @@ func TestTruncateRunes(t *testing.T) {
 func TestCreateListTitleTruncation(t *testing.T) {
 	mux, store := setupTestServer()
 
-	// 101文字のタイトル（最大100文字に切り詰められる）
 	longTitle := strings.Repeat("あ", 101)
 	form := url.Values{"title": {longTitle}}
 	req := httptest.NewRequest("POST", "/lists", strings.NewReader(form.Encode()))
@@ -512,10 +511,11 @@ func TestSecurityHeaders(t *testing.T) {
 	handler.ServeHTTP(w, req)
 
 	tests := map[string]string{
-		"X-Content-Type-Options": "nosniff",
-		"X-Frame-Options":       "DENY",
-		"Referrer-Policy":       "strict-origin-when-cross-origin",
-		"Permissions-Policy":    "camera=(), microphone=(), geolocation=()",
+		"X-Content-Type-Options":  "nosniff",
+		"X-Frame-Options":         "DENY",
+		"Referrer-Policy":         "strict-origin-when-cross-origin",
+		"Permissions-Policy":      "camera=(), microphone=(), geolocation=()",
+		"Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; form-action 'self'; frame-ancestors 'none'",
 	}
 	for header, expected := range tests {
 		got := w.Header().Get(header)
@@ -571,5 +571,44 @@ func TestBuildShareURL(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.expected, got)
 			}
 		})
+	}
+}
+
+func TestInvalidTokenFormat(t *testing.T) {
+	mux, _ := setupTestServer()
+	invalidTokens := []string{
+		"short",
+		"../../../etc/passwd",
+		"nonexistent-token",
+		"AABBCCDD11223344AABBCCDD11223344",
+		"gg112233445566778899aabbccddeeff",
+	}
+	for _, token := range invalidTokens {
+		req := httptest.NewRequest("GET", "/lists/"+token, nil)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("GET /lists/%s: expected 400, got %d", token, w.Code)
+		}
+	}
+}
+
+func TestInvalidTokenFormatOnDelete(t *testing.T) {
+	mux, _ := setupTestServer()
+	req := httptest.NewRequest("POST", "/lists/invalid-token/delete", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid token on delete, got %d", w.Code)
+	}
+}
+
+func TestGenerateTokenLength(t *testing.T) {
+	token := generateToken()
+	if len(token) != 32 {
+		t.Fatalf("expected token length 32, got %d", len(token))
+	}
+	if !validToken.MatchString(token) {
+		t.Fatalf("generated token %q does not match expected format", token)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func securityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; form-action 'self'; frame-ancestors 'none'")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/store.go
+++ b/store.go
@@ -25,7 +25,7 @@ func (s *Store) genID() string {
 }
 
 func generateToken() string {
-	b := make([]byte, 8)
+	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
 		panic("乱数生成に失敗しました: " + err.Error())
 	}


### PR DESCRIPTION
## 変更概要\n\n- `securityHeaders` ミドルウェアにContent-Security-Policy (CSP) ヘッダを追加\n- `generateToken()` のバイトサイズを8→16に拡大（16hex文字→32hex文字）\n- 正規表現 `^[a-f0-9]{32}$` によるトークン形式バリデーションを全ハンドラーに追加\n- 不正なトークン形式（パストラバーサル文字列等）はストア検索前に400で拒否\n- CSPヘッダ検証・トークンバリデーション・トークン長のテスト追加\n\nCloses #22\n\n## 動作確認手順\n1. `go test -v -race ./...` で全テストパス確認\n2. `go vet ./...` で静的解析パス確認\n3. サーバー起動後、レスポンスヘッダにCSPが含まれることを確認\n4. `/lists/invalid` へアクセスし400が返ることを確認\n5. リスト作成後、トークンが32文字のhex文字列であることを確認