### PR TITLE
セキュリティ強化: CSPヘッダ追加・トークンバリデーション・トークンサイズ拡大

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -53,6 +54,8 @@ var tmpl = template.Must(template.New("").Funcs(template.FuncMap{
 		return done * 100 / len(items)
 	},
 }).ParseGlob("templates/*.html"))
+
+var validToken = regexp.MustCompile(`^[a-f0-9]{32}$`)
 
 func registerRoutes(mux *http.ServeMux, store *Store) {
 	mux.HandleFunc("GET /health", handleHealth)
@@ -123,6 +126,10 @@ func handleCreateList(store *Store) http.HandlerFunc {
 func handleShowList(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if !validToken.MatchString(token) {
+			http.Error(w, "無効なトークン形式です", http.StatusBadRequest)
+			return
+		}
 		l := store.GetList(token)
 		if l == nil {
 			http.NotFound(w, r)
@@ -142,6 +149,10 @@ func handleShowList(store *Store) http.HandlerFunc {
 func handleAddItem(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if !validToken.MatchString(token) {
+			http.Error(w, "無効なトークン形式です", http.StatusBadRequest)
+			return
+		}
 		if store.GetList(token) == nil {
 			http.NotFound(w, r)
 			return
@@ -162,6 +173,10 @@ func handleAddItem(store *Store) http.HandlerFunc {
 func handleTogglePrepared(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if !validToken.MatchString(token) {
+			http.Error(w, "無効なトークン形式です", http.StatusBadRequest)
+			return
+		}
 		if store.GetList(token) == nil {
 			http.NotFound(w, r)
 			return
@@ -175,6 +190,10 @@ func handleTogglePrepared(store *Store) http.HandlerFunc {
 func handleToggleRequired(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if !validToken.MatchString(token) {
+			http.Error(w, "無効なトークン形式です", http.StatusBadRequest)
+			return
+		}
 		if store.GetList(token) == nil {
 			http.NotFound(w, r)
 			return
@@ -188,6 +207,10 @@ func handleToggleRequired(store *Store) http.HandlerFunc {
 func handleUpdateAssignee(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if !validToken.MatchString(token) {
+			http.Error(w, "無効なトークン形式です", http.StatusBadRequest)
+			return
+		}
 		if store.GetList(token) == nil {
 			http.NotFound(w, r)
 			return
@@ -202,6 +225,10 @@ func handleUpdateAssignee(store *Store) http.HandlerFunc {
 func handleDeleteItem(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if !validToken.MatchString(token) {
+			http.Error(w, "無効なトークン形式です", http.StatusBadRequest)
+			return
+		}
 		if store.GetList(token) == nil {
 			http.NotFound(w, r)
 			return
@@ -215,6 +242,10 @@ func handleDeleteItem(store *Store) http.HandlerFunc {
 func handleDeleteList(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token := r.PathValue("token")
+		if !validToken.MatchString(token) {
+			http.Error(w, "無効なトークン形式です", http.StatusBadRequest)
+			return
+		}
 		if !store.DeleteList(token) {
 			http.NotFound(w, r)
 			return

--- a/handler_test.go
+++ b/handler_test.go
@@ -172,7 +172,7 @@ func TestUpdateAssignee(t *testing.T) {
 
 func TestNotFoundList(t *testing.T) {
 	mux, _ := setupTestServer()
-	req := httptest.NewRequest("GET", "/lists/nonexistent", nil)
+	req := httptest.NewRequest("GET", "/lists/00112233445566778899aabbccddeeff", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -229,7 +229,7 @@ func TestDeleteList(t *testing.T) {
 
 func TestDeleteListNotFound(t *testing.T) {
 	mux, _ := setupTestServer()
-	req := httptest.NewRequest("POST", "/lists/nonexistent-token/delete", nil)
+	req := httptest.NewRequest("POST", "/lists/00112233445566778899aabbccddeeff/delete", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -506,7 +506,7 @@ func TestUpdateAssigneeTruncation(t *testing.T) {
 func TestHandlerAddItemToNonExistentList(t *testing.T) {
 	mux, _ := setupTestServer()
 	form := url.Values{"name": {"テント"}, "assignee": {"太郎"}}
-	req := httptest.NewRequest("POST", "/lists/nonexistent-token/items", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest("POST", "/lists/00112233445566778899aabbccddeeff/items", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
@@ -518,7 +518,7 @@ func TestHandlerAddItemToNonExistentList(t *testing.T) {
 
 func TestTogglePreparedOnNonExistentList(t *testing.T) {
 	mux, _ := setupTestServer()
-	req := httptest.NewRequest("POST", "/lists/nonexistent-token/items/1/toggle-prepared", nil)
+	req := httptest.NewRequest("POST", "/lists/00112233445566778899aabbccddeeff/items/1/toggle-prepared", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -529,7 +529,7 @@ func TestTogglePreparedOnNonExistentList(t *testing.T) {
 
 func TestToggleRequiredOnNonExistentList(t *testing.T) {
 	mux, _ := setupTestServer()
-	req := httptest.NewRequest("POST", "/lists/nonexistent-token/items/1/toggle-required", nil)
+	req := httptest.NewRequest("POST", "/lists/00112233445566778899aabbccddeeff/items/1/toggle-required", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -541,7 +541,7 @@ func TestToggleRequiredOnNonExistentList(t *testing.T) {
 func TestUpdateAssigneeOnNonExistentList(t *testing.T) {
 	mux, _ := setupTestServer()
 	form := url.Values{"assignee": {"花子"}}
-	req := httptest.NewRequest("POST", "/lists/nonexistent-token/items/1/assignee", strings.NewReader(form.Encode()))
+	req := httptest.NewRequest("POST", "/lists/00112233445566778899aabbccddeeff/items/1/assignee", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
@@ -553,7 +553,7 @@ func TestUpdateAssigneeOnNonExistentList(t *testing.T) {
 
 func TestDeleteItemOnNonExistentList(t *testing.T) {
 	mux, _ := setupTestServer()
-	req := httptest.NewRequest("POST", "/lists/nonexistent-token/items/1/delete", nil)
+	req := httptest.NewRequest("POST", "/lists/00112233445566778899aabbccddeeff/items/1/delete", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -574,7 +574,8 @@ func TestSecurityHeaders(t *testing.T) {
 		"X-Content-Type-Options": "nosniff",
 		"X-Frame-Options":       "DENY",
 		"Referrer-Policy":       "strict-origin-when-cross-origin",
-		"Permissions-Policy":    "camera=(), microphone=(), geolocation=()",
+		"Permissions-Policy":      "camera=(), microphone=(), geolocation=()",
+		"Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; form-action 'self'; frame-ancestors 'none'",
 	}
 	for header, expected := range tests {
 		got := w.Header().Get(header)
@@ -630,5 +631,44 @@ func TestBuildShareURL(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.expected, got)
 			}
 		})
+	}
+}
+
+func TestInvalidTokenFormat(t *testing.T) {
+	mux, _ := setupTestServer()
+	invalidTokens := []string{
+		"short",
+		"../../../etc/passwd",
+		"nonexistent-token",
+		"AABBCCDD11223344AABBCCDD11223344",
+		"gg112233445566778899aabbccddeeff",
+	}
+	for _, token := range invalidTokens {
+		req := httptest.NewRequest("GET", "/lists/"+token, nil)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("GET /lists/%s: expected 400, got %d", token, w.Code)
+		}
+	}
+}
+
+func TestInvalidTokenFormatOnDelete(t *testing.T) {
+	mux, _ := setupTestServer()
+	req := httptest.NewRequest("POST", "/lists/invalid-token/delete", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid token on delete, got %d", w.Code)
+	}
+}
+
+func TestGenerateTokenLength(t *testing.T) {
+	token := generateToken()
+	if len(token) != 32 {
+		t.Fatalf("expected token length 32, got %d", len(token))
+	}
+	if !validToken.MatchString(token) {
+		t.Fatalf("generated token %q does not match expected format", token)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func securityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; form-action 'self'; frame-ancestors 'none'")
 		next.ServeHTTP(w, r)
 	})
 }
@@ -93,3 +94,4 @@ func main() {
 	}
 	slog.Info("サーバーを正常に停止しました")
 }
+

--- a/store.go
+++ b/store.go
@@ -25,7 +25,7 @@ func (s *Store) genID() string {
 }
 
 func generateToken() string {
-	b := make([]byte, 8)
+	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
 		panic("乱数生成に失敗しました: " + err.Error())
 	}


### PR DESCRIPTION
## 変更概要

- `securityHeaders` ミドルウェアにCSPヘッダを追加
- `generateToken()` のバイトサイズを8→16に拡大（32hex文字）
- 正規表現 `^[a-f0-9]{32}$` によるトークンバリデーションを全ハンドラーに追加
- 不正なトークン形式はストア検索前に400で拒否
- 関連テスト追加

Closes #22

## 動作確認手順
1. `go test -v -race ./...` で全テストパス確認
2. `go vet ./...` で静的解析パス確認